### PR TITLE
Copy rx buffer before passing to goroutine

### DIFF
--- a/stoneflow.go
+++ b/stoneflow.go
@@ -403,10 +403,15 @@ func (stoneflow *StoneFlow) StartSFlow() {
 
 	for {
 		buf := make([]byte, 1500)
-		_, _, err := l.ReadFromUDP(buf)
+		n, _, err := l.ReadFromUDP(buf)
 		stoneflow.CheckError(err)
 		//log.Debugf("Received from %v: %v\n", addr, buf)
-		go stoneflow.DatagramHandler(buf)
+
+		// Make a copy of the received data
+		pkt := make([]byte, n)
+		copy(pkt, buf)
+
+		go stoneflow.DatagramHandler(pkt)
 	}
 }
 


### PR DESCRIPTION
Slices hold a pointer to an underlying array. If the original buffer
is passed to the goroutine, the receive loop may write a new packet
into the array while the goroutine is still processing the previous packet,
resulting in a data race.
